### PR TITLE
fix: prevent error on first run

### DIFF
--- a/notificator
+++ b/notificator
@@ -108,7 +108,7 @@ readonly app="${alfred_workflow_cache}/Notificator for ${name}.app"
 readonly plist="${app}/Contents/Info.plist"
 
 # Exit early if Notificator exists and was modified fewer than 30 days ago
-if [[ "$(/bin/date -r "${app}" +%s)" -gt "$(/bin/date -v -30d +%s)" ]]
+if [[ -d "${app} && "$(/bin/date -r "${app}" +%s)" -gt "$(/bin/date -v -30d +%s)" ]]
 then
   show_notification
   exit 0


### PR DESCRIPTION
On the first run, `$app` does not exist yet, causing `date` to fail. This has no grave consequences, just results in an unnecessary (and at first bit confusing) error message, which this fix removes.

```bash
> ./notificator --message "foobar"
usage: date [-jnRu] [-I[date|hours|minutes|seconds]] [-f input_fmt]
            [-r filename|seconds] [-v[+|-]val[y|m|w|d|H|M|S]]
            [[[[mm]dd]HH]MM[[cc]yy][.SS] | new_date] [+output_fmt]
```